### PR TITLE
Fix Issue with API key not being used.

### DIFF
--- a/src/io/filepicker/FilePickerAPI.java
+++ b/src/io/filepicker/FilePickerAPI.java
@@ -156,7 +156,7 @@ public class FilePickerAPI {
 	public final static String FPHOSTNAME = "www.filepicker.io";
 	public final static String FPBASEURL = "https://" + FPHOSTNAME + "/";
 	public static String FPAPIKEY = "ADkvlBBC4ReOhGkybgqRHz";//"";
-	public final static String FILE_GET_JS_SESSION_PART = "{\"app\":{\"apikey\":\""
+	public static String FILE_GET_JS_SESSION_PART = "{\"app\":{\"apikey\":\""
 			+ FPAPIKEY + "\"}";
 	public final static int REQUEST_CODE_AUTH = 600;
 	public final static int REQUEST_CODE_GETFILE = 601;
@@ -180,6 +180,8 @@ public class FilePickerAPI {
 
 	public static void setKey(String key) {
 		FPAPIKEY = key;
+		FILE_GET_JS_SESSION_PART = "{\"app\":{\"apikey\":\""
+			+ FPAPIKEY + "\"}";
 	}
 
 	protected static boolean isKeySet() {


### PR DESCRIPTION
There was an issue with the constant FILE_GET_JS_SESSION_PART in that it was initialized statically with the default API key and it wasn't update when the user called FilePicker.setKey().
