### PR TITLE
Update to latest build tools and android gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,8 @@ out*
 # Android Lint Tool configuration file
 lint.xml
 
+# Gradle
+build
+.gradle
+
 

--- a/filepicker-library/build.gradle
+++ b/filepicker-library/build.gradle
@@ -1,25 +1,32 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.5.+'
+        classpath 'com.android.tools.build:gradle:0.13.+'
     }
 }
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile 'com.android.support:support-v4:21.0.0'
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.0.3"
+    compileSdkVersion 21
+    buildToolsVersion "21.0.2"
+
+    lintOptions {
+        abortOnError false
+    }
 
     defaultConfig {
+        versionCode 1
+        versionName "1.1"
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 21
     }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -31,7 +38,7 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        instrumentTest.setRoot('tests')
+        androidTest.setRoot('tests')
     }
 }
 

--- a/sample-studio/build.gradle
+++ b/sample-studio/build.gradle
@@ -1,15 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.13.+'
     }
 }
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }

--- a/sample-studio/sample/build.gradle
+++ b/sample-studio/sample/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
-    }
-}
 apply plugin: 'android'
 
 repositories {
@@ -13,18 +5,18 @@ repositories {
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.0.3'
+    compileSdkVersion 21
+    buildToolsVersion '21.0.2'
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 21
     }
     productFlavors {
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:19.0.1'
+    compile 'com.android.support:support-v4:21.0.0'
     compile project(':filepicker-library')
     compile 'com.squareup.picasso:picasso:2.3.1'
 }


### PR DESCRIPTION
Update to use Android Gradle Plugin version 0.13.+ to be able to import into latest Android Studio version. This also allows to build from command line. Android Support library also updated to latest version. 
