### PR TITLE
Fix crash for when actionbar up icon is pressed in AuthActivity.

### DIFF
--- a/filepicker-library/AndroidManifest.xml
+++ b/filepicker-library/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
         <activity
             android:name=".FilePicker"
+            android:launchMode="singleTop"
             android:label="@string/title_activity_file_picker" >
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT" />
@@ -32,7 +33,7 @@
             android:label="@string/title_activity_file_picker_auth" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="FilePicker" />
+                android:value="io.filepicker.FilePicker" />
         </activity>
     </application>
 


### PR DESCRIPTION
File Picker currently crashes when pressing the up icon in the actionbar when in AuthActivity. This happens because parent meta data is not properly set. The FilePicker activity is also set to singletop otherwise another instance is created. 
