### PR TITLE
Catch nullpointer exception when no cursor is returned.

### DIFF
--- a/filepicker-library/src/io/filepicker/FilePickerAPI.java
+++ b/filepicker-library/src/io/filepicker/FilePickerAPI.java
@@ -636,6 +636,9 @@ public class FilePickerAPI {
             int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
             cursor.moveToFirst();
             return cursor.getString(column_index);
+        }catch(Exception e){
+          e.printStackTrace();
+          return null;
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
The cursor in FilePickerApi.getRealPathFromURI(Context context, Uri contentUri) can be null for some devices and emulators. If this happens you end up with a nullpointer exception. When this happens fpurl is never set because a FPFile is never returned.
