### PR TITLE
Remove hardcoded pixels in FilePicker

### DIFF
--- a/filepicker-library/res/layout/row_fpi_node_view.xml
+++ b/filepicker-library/res/layout/row_fpi_node_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <ImageView
+    android:id="@+id/nodeImageView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:padding="16dp" />
+
+  <TextView
+    android:id="@+id/nodeTextView"
+    android:layout_width="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:gravity="center_vertical"
+    android:layout_height="?android:listPreferredItemHeight"
+    android:textAppearance="?android:textAppearanceMedium" />
+
+</merge>

--- a/filepicker-library/src/io/filepicker/FilePicker.java
+++ b/filepicker-library/src/io/filepicker/FilePicker.java
@@ -1,5 +1,6 @@
 package io.filepicker;
 
+import android.content.res.Resources;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -83,20 +84,17 @@ public class FilePicker extends Activity {
 
     class FPInodeView extends LinearLayout {
         public FPInodeView(Context context, Inode inode, boolean thumbnail) {
-            super(FilePicker.this);
-            setMinimumHeight(96);
+            super(context);
             setOrientation(LinearLayout.HORIZONTAL);
             setGravity(Gravity.CENTER_VERTICAL);
 
-            TextView textView = new TextView(FilePicker.this);
-            textView.setTextSize(18.0f);
+            View row = inflate(context, R.layout.row_fpi_node_view, this);
 
+            TextView textView = (TextView) row.findViewById(R.id.nodeTextView);
             textView.setText(inode.getDisplayName());
 
-            ImageView icon = new ImageView(FilePicker.this);
+            ImageView icon = (ImageView) row.findViewById(R.id.nodeImageView);
             icon.setImageResource(inode.getImageResource());
-            icon.setPadding(14, 18, 12, 16);
-            addView(icon);
 
             if (inode.isDisabled())
                 textView.setTextColor(Color.GRAY);
@@ -104,8 +102,6 @@ public class FilePicker extends Activity {
                 textView.setTextColor(Color.WHITE);
                 icon.setColorFilter(0xffffffff, Mode.XOR);
             }
-
-            addView(textView);
 
             if (inode.getIsDir()) {
                 FilePickerAPI.getInstance()


### PR DESCRIPTION
The pixels hardcoded in FPInodeView make the rows look very small in phones such as an Htc One. Inflating a row that uses dp solves this UI bug. 
![filepicker-htc-one-hardcode](https://cloud.githubusercontent.com/assets/507510/4836613/4b468c8e-5fc7-11e4-93e4-9be2fc0f5a9c.png)

![filepicker-htc-one-dp-dimensions](https://cloud.githubusercontent.com/assets/507510/4836614/4e3de32e-5fc7-11e4-84af-d23ffb57c55b.png)
