### PR TITLE
Return MIME type, not extension

### DIFF
--- a/filepicker-library/src/io/filepicker/utils/FilesUtils.java
+++ b/filepicker-library/src/io/filepicker/utils/FilesUtils.java
@@ -32,7 +32,8 @@ public class FilesUtils {
         if("content".equalsIgnoreCase(uri.getScheme())) {
             mimetype = context.getContentResolver().getType(uri);
         } else {
-            mimetype = MimeTypeMap.getFileExtensionFromUrl(uri.getPath());
+            String extension = MimeTypeMap.getFileExtensionFromUrl(uri.getPath());
+            mimetype = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         }
 
         if(mimetype == null) {


### PR DESCRIPTION
This method incorrectly returns the file extension, and not the MIME type, causing `Utils.getUploadedFilename()` to always return "Image..." and not "Video...".