### PR TITLE
Update AndroidManifest.xml for Android S

### DIFF
--- a/filestack/src/main/AndroidManifest.xml
+++ b/filestack/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
             android:name=".FsActivity"
             android:launchMode="singleTop"
             android:label="@string/filestack__picker_title"
-            android:theme="@style/FilestackNoActionBar">
+            android:theme="@style/FilestackNoActionBar"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
The latest version of Android requires all activities that use an intent-filter to specify whether or not they're exported (https://developer.android.com/about/versions/12/behavior-changes-12#exported).

Currently, anyone using filestack-android will have their build broken when compiling for S